### PR TITLE
Add PDF to image converter utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Florence-2-FineTuning provides tools to fine‑tune Microsoft’s [Florence‑2]
 ## Table of Contents
 - [Installation](#installation)
 - [Dataset Creation](#dataset-creation)
+- [PDF to Image Conversion](#pdf-to-image-conversion)
 - [Training](#training)
 - [Evaluation](#evaluation)
 - [Repository Structure](#repository-structure)
@@ -49,6 +50,13 @@ It assigns a unique ID to each image and stores the corresponding metadata in th
 }
 ```
 You can use [DocumentVQA](https://huggingface.co/datasets/HuggingFaceM4/DocumentVQA) as a reference dataset.
+
+## PDF to Image Conversion
+Convert scanned documents into images with `pdf_to_images.py`:
+```bash
+python pdf_to_images.py <input.pdf> --output_folder images_out
+```
+Each page of the PDF is saved as an individual image inside the specified folder.
 
 ## Training
 Launch training with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ timm==1.0.7
 tokenizers==0.19.1
 tqdm==4.66.4
 transformers==4.42.4
+pdf2image==1.17.0

--- a/scripts/pdf_to_images.py
+++ b/scripts/pdf_to_images.py
@@ -1,0 +1,44 @@
+import argparse
+import os
+from pdf2image import convert_from_path
+
+
+def convert_pdf_to_images(pdf_path, output_folder, dpi=300, fmt="png"):
+    """Convert all pages of a PDF to images.
+
+    Args:
+        pdf_path (str): Path to the input PDF file.
+        output_folder (str): Directory where images will be saved.
+        dpi (int, optional): Resolution in DPI. Defaults to 300.
+        fmt (str, optional): Image format (png or jpeg). Defaults to "png".
+
+    Returns:
+        list[str]: Paths to the generated image files.
+    """
+    os.makedirs(output_folder, exist_ok=True)
+    pages = convert_from_path(pdf_path, dpi=dpi)
+    image_paths = []
+    base = os.path.splitext(os.path.basename(pdf_path))[0]
+    for i, page in enumerate(pages, start=1):
+        image_path = os.path.join(output_folder, f"{base}_{i}.{fmt}")
+        page.save(image_path, fmt.upper())
+        image_paths.append(image_path)
+    return image_paths
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert PDF pages into images.")
+    parser.add_argument("pdf_path", help="Path to the PDF document")
+    parser.add_argument("--output_folder", default="images_out", help="Folder to save images")
+    parser.add_argument("--dpi", type=int, default=300, help="Output image resolution (DPI)")
+    parser.add_argument("--format", choices=["png", "jpeg", "jpg"], default="png", help="Image format")
+    args = parser.parse_args()
+
+    images = convert_pdf_to_images(args.pdf_path, args.output_folder, dpi=args.dpi, fmt=args.format)
+    print(f"Saved {len(images)} images to {args.output_folder}")
+    for img in images:
+        print(img)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pdf_to_images.py
+++ b/tests/test_pdf_to_images.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import sys
+from PIL import Image
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.pdf_to_images import convert_pdf_to_images
+
+def test_convert_pdf_to_images(tmp_path):
+    pdf_path = tmp_path / "test.pdf"
+    Image.new("RGB", (10, 10), color="white").save(pdf_path, "PDF")
+    out_dir = tmp_path / "images"
+    result = convert_pdf_to_images(str(pdf_path), str(out_dir), dpi=50)
+    assert len(result) == 1
+    assert Path(result[0]).exists()


### PR DESCRIPTION
## Summary
- implement `pdf_to_images.py` to split PDF pages into images
- document the converter in the README
- add `pdf2image` dependency
- test PDF conversion logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68401d89385c8326a3516c4593ef4b65