### PR TITLE
Add metrics utilities and example scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ python val.py --task_prompt "DETAILED_CAPTION" --text_input "What do you see in 
 ```
 `task_prompt` selects the Florence‑2 task (e.g., `CAPTION`, `DETAILED_CAPTION`). See the Hugging Face model page for additional prompts.
 
+Two utility metrics are provided for other tasks:
+- **Accuracy** for classification via `florence.metrics.accuracy`.
+- **IoU** for segmentation via `florence.metrics.iou_score`.
+Example scripts `example_classification.py` and `example_segmentation.py` demonstrate their use.
+
 ## Tutorials
 Step‑by‑step Jupyter notebooks in the `notebooks/` folder show how to create a dataset, train a model and run inference for quick experimentation.
 
@@ -90,6 +95,8 @@ The project now follows a modular layout:
 - Updated documentation structure for clarity.
 - Added usage examples for `createdataset.py`, `train.py` and `val.py`.
 - Established an extension point for future **object detection** capabilities.
+- Introduced `accuracy` and `iou_score` metrics with example scripts for
+  classification and segmentation.
 
 ## Future Work
 - **Evaluation Script**: automated benchmark utilities.

--- a/scripts/example_classification.py
+++ b/scripts/example_classification.py
@@ -1,0 +1,41 @@
+"""Example Florence-2 image classification script."""
+
+import argparse
+import torch
+from transformers import AutoModelForImageClassification, AutoProcessor
+
+from florence.metrics import accuracy
+from florence.dataset_utils import load_local_dataset, ClassificationDataset
+
+
+def run(model_name: str, dataset_folder: str) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = AutoModelForImageClassification.from_pretrained(model_name, trust_remote_code=True).to(device)
+    processor = AutoProcessor.from_pretrained(model_name, trust_remote_code=True)
+
+    data = load_local_dataset(dataset_folder, task_type="Classification")
+    dataset = ClassificationDataset(data)
+
+    preds, labels = [], []
+    for image, label in dataset:
+        inputs = processor(images=image, return_tensors="pt").to(device)
+        with torch.no_grad():
+            logits = model(**inputs).logits
+        pred = logits.argmax(dim=-1).item()
+        preds.append(pred)
+        labels.append(label)
+
+    acc = accuracy(preds, labels)
+    print(f"Accuracy: {acc:.4f}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a Florence-2 classification example")
+    parser.add_argument("--dataset_folder", type=str, required=True, help="Folder with JSON/PNG pairs and labels")
+    parser.add_argument("--model_name", type=str, default="microsoft/Florence-2-base-ft", help="Model name")
+    args = parser.parse_args()
+    run(args.model_name, args.dataset_folder)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/example_segmentation.py
+++ b/scripts/example_segmentation.py
@@ -1,0 +1,41 @@
+"""Example Florence-2 segmentation script."""
+
+import argparse
+import numpy as np
+import torch
+from transformers import AutoModelForImageSegmentation, AutoProcessor
+from florence.metrics import iou_score
+from florence.dataset_utils import load_local_dataset, SegmentationDataset
+
+
+def run(model_name: str, dataset_folder: str) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = AutoModelForImageSegmentation.from_pretrained(model_name, trust_remote_code=True).to(device)
+    processor = AutoProcessor.from_pretrained(model_name, trust_remote_code=True)
+
+    data = load_local_dataset(dataset_folder, task_type="Segmentation")
+    dataset = SegmentationDataset(data)
+
+    ious = []
+    for image, mask in dataset:
+        inputs = processor(images=image, return_tensors="pt").to(device)
+        with torch.no_grad():
+            outputs = model(**inputs)
+        pred_mask = outputs.logits.argmax(dim=1)[0].cpu().numpy()
+        true_mask = np.array(mask)
+        ious.append(iou_score(pred_mask, true_mask, num_classes=outputs.logits.shape[1]))
+
+    mean_iou = sum(ious) / len(ious) if ious else 0.0
+    print(f"Mean IoU: {mean_iou:.4f}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a Florence-2 segmentation example")
+    parser.add_argument("--dataset_folder", type=str, required=True, help="Folder with JSON/PNG and mask files")
+    parser.add_argument("--model_name", type=str, default="microsoft/Florence-2-base-ft", help="Model name")
+    args = parser.parse_args()
+    run(args.model_name, args.dataset_folder)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/florence/__init__.py
+++ b/src/florence/__init__.py
@@ -1,0 +1,24 @@
+"""Florence utility modules."""
+
+from .dataset_utils import (
+    load_local_dataset,
+    DocVQADataset,
+    ObjectDetectionDataset,
+    ClassificationDataset,
+    SegmentationDataset,
+    kfold_split,
+    stratified_split,
+)
+from .metrics import accuracy, iou_score
+
+__all__ = [
+    "load_local_dataset",
+    "DocVQADataset",
+    "ObjectDetectionDataset",
+    "ClassificationDataset",
+    "SegmentationDataset",
+    "kfold_split",
+    "stratified_split",
+    "accuracy",
+    "iou_score",
+]

--- a/src/florence/metrics.py
+++ b/src/florence/metrics.py
@@ -1,0 +1,55 @@
+"""Utility metrics for model evaluation."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def accuracy(preds, labels):
+    """Compute classification accuracy.
+
+    Parameters
+    ----------
+    preds : sequence of int or str
+        Predicted labels.
+    labels : sequence of int or str
+        Ground truth labels.
+
+    Returns
+    -------
+    float
+        Fraction of correct predictions.
+    """
+    if len(preds) != len(labels):
+        raise ValueError("preds and labels must have the same length")
+    correct = sum(p == t for p, t in zip(preds, labels))
+    return correct / len(labels) if labels else 0.0
+
+
+def iou_score(pred_mask: np.ndarray, true_mask: np.ndarray, num_classes: int) -> float:
+    """Compute mean Intersection over Union (IoU) for segmentation masks.
+
+    Parameters
+    ----------
+    pred_mask : ndarray
+        Predicted mask with integer class values.
+    true_mask : ndarray
+        Ground truth mask with integer class values.
+    num_classes : int
+        Number of classes present in the masks.
+
+    Returns
+    -------
+    float
+        Mean IoU across classes (ignoring classes with no pixels).
+    """
+    ious = []
+    for cls in range(num_classes):
+        pred = pred_mask == cls
+        true = true_mask == cls
+        intersection = np.logical_and(pred, true).sum()
+        union = np.logical_or(pred, true).sum()
+        if union == 0:
+            continue
+        ious.append(intersection / union)
+    return float(np.mean(ious)) if ious else 0.0

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -7,6 +7,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
 from florence.dataset_utils import (
     load_local_dataset,
     ObjectDetectionDataset,
+    ClassificationDataset,
+    SegmentationDataset,
     kfold_split,
     stratified_split,
 )
@@ -23,6 +25,30 @@ def test_object_detection_dataset(tmp_path):
     image, target = dataset[0]
     assert target["boxes"][0] == [1, 2, 3, 4]
     assert target["labels"][0] == "cat"
+
+
+def test_classification_dataset(tmp_path):
+    img_path = tmp_path / "1.png"
+    Image.new("RGB", (5, 5), color="white").save(img_path)
+    with open(tmp_path / "1.json", "w") as f:
+        json.dump({"label": 1}, f)
+    data = load_local_dataset(str(tmp_path), task_type="Classification")
+    dataset = ClassificationDataset(data)
+    image, label = dataset[0]
+    assert label == 1
+
+
+def test_segmentation_dataset(tmp_path):
+    img_path = tmp_path / "1.png"
+    mask_path = tmp_path / "1_mask.png"
+    Image.new("RGB", (5, 5), color="white").save(img_path)
+    Image.new("L", (5, 5), color=0).save(mask_path)
+    with open(tmp_path / "1.json", "w") as f:
+        json.dump({}, f)
+    data = load_local_dataset(str(tmp_path), task_type="Segmentation")
+    dataset = SegmentationDataset(data)
+    image, mask = dataset[0]
+    assert mask.size == (5, 5)
 
 
 def test_kfold_split():

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,16 @@
+import numpy as np
+import pytest
+from florence.metrics import accuracy, iou_score
+
+
+def test_accuracy():
+    preds = [0, 1, 2]
+    labels = [0, 0, 2]
+    assert accuracy(preds, labels) == pytest.approx(2/3)
+
+def test_iou_score():
+    pred = np.array([[0, 1], [1, 1]])
+    true = np.array([[0, 0], [1, 1]])
+    iou = iou_score(pred, true, num_classes=2)
+    expected = (1/2 + 2/3) / 2
+    assert iou == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- add `accuracy` and `iou_score` utilities
- extend dataset loader with classification and segmentation support
- include example scripts for classification and segmentation tasks
- document new metrics and scripts
- add unit tests for metrics and new dataset types

## Testing
- `pip install pillow numpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68401e1d40608326862152310e584914