### PR TITLE
Add classification and segmentation metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ python val.py --task_prompt "DETAILED_CAPTION" --text_input "What do you see in 
 ```
 `task_prompt` selects the Florence‑2 task (e.g., `CAPTION`, `DETAILED_CAPTION`). See the Hugging Face model page for additional prompts.
 
+### Classification & Segmentation Metrics
+Two helper functions are available for common evaluation tasks:
+
+```python
+from florence.metrics import classification_accuracy, segmentation_iou
+```
+
+The scripts `example_classification.py` and `example_segmentation.py` demonstrate how to compute accuracy and IoU respectively.
+
 ## Tutorials
 Step‑by‑step Jupyter notebooks in the `notebooks/` folder show how to create a dataset, train a model and run inference for quick experimentation.
 
@@ -90,6 +99,7 @@ The project now follows a modular layout:
 - Updated documentation structure for clarity.
 - Added usage examples for `createdataset.py`, `train.py` and `val.py`.
 - Established an extension point for future **object detection** capabilities.
+- Added accuracy and IoU metrics with example scripts for classification and segmentation tasks.
 
 ## Future Work
 - **Evaluation Script**: automated benchmark utilities.

--- a/scripts/example_classification.py
+++ b/scripts/example_classification.py
@@ -1,0 +1,10 @@
+"""Example script showing classification accuracy calculation."""
+from florence.metrics import classification_accuracy
+
+
+if __name__ == "__main__":
+    # Example predictions and labels
+    predictions = [0, 1, 1, 0]
+    labels = [0, 1, 0, 0]
+    acc = classification_accuracy(predictions, labels)
+    print(f"Accuracy: {acc:.2f}")

--- a/scripts/example_segmentation.py
+++ b/scripts/example_segmentation.py
@@ -1,0 +1,17 @@
+"""Example script showing segmentation IoU calculation."""
+import numpy as np
+from PIL import Image
+from florence.metrics import segmentation_iou
+
+
+if __name__ == "__main__":
+    # create simple binary masks
+    pred = Image.new("1", (4, 4), 0)
+    gt = Image.new("1", (4, 4), 0)
+    for x in range(2):
+        for y in range(2):
+            pred.putpixel((x, y), 1)
+    for x in range(3):
+        gt.putpixel((x, 0), 1)
+    iou = segmentation_iou(np.array(pred), np.array(gt))
+    print(f"IoU: {iou:.2f}")

--- a/src/florence/__init__.py
+++ b/src/florence/__init__.py
@@ -1,0 +1,18 @@
+from .dataset_utils import (
+    load_local_dataset,
+    DocVQADataset,
+    ObjectDetectionDataset,
+    kfold_split,
+    stratified_split,
+)
+from .metrics import classification_accuracy, segmentation_iou
+
+__all__ = [
+    "load_local_dataset",
+    "DocVQADataset",
+    "ObjectDetectionDataset",
+    "kfold_split",
+    "stratified_split",
+    "classification_accuracy",
+    "segmentation_iou",
+]

--- a/src/florence/metrics.py
+++ b/src/florence/metrics.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+
+def classification_accuracy(preds, labels):
+    """Compute accuracy for classification.
+
+    Parameters
+    ----------
+    preds : Sequence
+        Predicted labels.
+    labels : Sequence
+        Ground truth labels.
+
+    Returns
+    -------
+    float
+        The fraction of correct predictions.
+    """
+    if len(preds) != len(labels):
+        raise ValueError("preds and labels must have the same length")
+    if len(labels) == 0:
+        return 0.0
+    correct = sum(p == l for p, l in zip(preds, labels))
+    return correct / len(labels)
+
+
+def segmentation_iou(pred_mask, target_mask):
+    """Compute the Intersection over Union (IoU) metric for segmentation masks.
+
+    Parameters
+    ----------
+    pred_mask : array-like
+        Predicted binary mask.
+    target_mask : array-like
+        Ground truth binary mask.
+
+    Returns
+    -------
+    float
+        IoU score between 0 and 1.
+    """
+    pred = np.array(pred_mask, dtype=bool)
+    target = np.array(target_mask, dtype=bool)
+    intersection = np.logical_and(pred, target).sum()
+    union = np.logical_or(pred, target).sum()
+    return float(intersection) / float(union) if union > 0 else 0.0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,16 @@
+import numpy as np
+from florence.metrics import classification_accuracy, segmentation_iou
+
+
+def test_classification_accuracy():
+    preds = [1, 0, 1, 1]
+    labels = [1, 0, 0, 1]
+    acc = classification_accuracy(preds, labels)
+    assert acc == 0.75
+
+
+def test_segmentation_iou():
+    pred = np.array([[1, 0], [1, 0]])
+    target = np.array([[1, 0], [0, 0]])
+    iou = segmentation_iou(pred, target)
+    assert iou == 0.5


### PR DESCRIPTION
## Summary
- expose new metrics module in `florence`
- implement `classification_accuracy` and `segmentation_iou`
- add example scripts demonstrating metrics usage
- document metrics in README
- test new metrics

## Testing
- `pip install Pillow numpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68401e4d21c48326a4f1366e586d9cfe